### PR TITLE
remove unhandled import arguments

### DIFF
--- a/t/01-simple.t
+++ b/t/01-simple.t
@@ -8,7 +8,7 @@ use constant {
 };
 use Test::More;
 use AnyEvent::Socket;
-use AnyEvent::MockTCPServer qw/:all/;
+use AnyEvent::MockTCPServer;
 
 my $done = AnyEvent->condvar;
 my $server;

--- a/t/02-unexpected.t
+++ b/t/02-unexpected.t
@@ -11,7 +11,7 @@ BEGIN {
 }
 use Test::More;
 use AnyEvent::Socket;
-use AnyEvent::MockTCPServer qw/:all/;
+use AnyEvent::MockTCPServer;
 
 my $done = AnyEvent->condvar;
 my $server;

--- a/t/03-two.t
+++ b/t/03-two.t
@@ -8,7 +8,7 @@ use constant {
 };
 use Test::More;
 use AnyEvent::Socket;
-use AnyEvent::MockTCPServer qw/:all/;
+use AnyEvent::MockTCPServer;
 
 my $done = AnyEvent->condvar;
 my $done2 = AnyEvent->condvar;

--- a/t/04-timeout.t
+++ b/t/04-timeout.t
@@ -11,7 +11,7 @@ BEGIN {
 }
 use Test::More;
 use AnyEvent::Socket;
-use AnyEvent::MockTCPServer qw/:all/;
+use AnyEvent::MockTCPServer;
 
 my $done = AnyEvent->condvar;
 my $server;

--- a/t/05-error.t
+++ b/t/05-error.t
@@ -11,7 +11,7 @@ BEGIN {
 }
 use Test::More;
 use AnyEvent::Socket;
-use AnyEvent::MockTCPServer qw/:all/;
+use AnyEvent::MockTCPServer;
 
 my $done = AnyEvent->condvar;
 my $server;


### PR DESCRIPTION
Previous versions of perl allow a use or import call even if the import method doesn't exist. Future versions are intending to throw errors for calls to an undefined import method that includes arguments.

Remove the arguments to use lines when the import method does not exist.